### PR TITLE
Add Laravel 13 to CI test matrix and fix path traversal test

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -22,9 +22,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.4, 8.3]
-        laravel: [12.*, 11.*,]
+        laravel: [13.*, 12.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 13.*
+            testbench: 11.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 11.*

--- a/src/Commands/ClearGlideCacheCommand.php
+++ b/src/Commands/ClearGlideCacheCommand.php
@@ -79,8 +79,7 @@ class ClearGlideCacheCommand extends Command
         $deleted = 0;
         $deletedBytes = 0;
 
-        $this->withProgressBar($files, function ($file) use ($fs, &$deleted, &$deletedBytes): void {
-            /** @var SplFileInfo $file */
+        $this->withProgressBar($files, function (SplFileInfo $file) use ($fs, &$deleted, &$deletedBytes): void {
             $size = $file->getSize();
             try {
                 $fs->delete($file->getPathname());

--- a/tests/Security/PathTraversalTest.php
+++ b/tests/Security/PathTraversalTest.php
@@ -124,6 +124,12 @@ describe('Path Traversal Security', function () {
     });
 
     it('allows valid paths after decoding', function () {
+        // Ensure the configured source directory exists for realpath() validation
+        $sourcePath = config('laravel-glider.source');
+        if (! is_dir($sourcePath)) {
+            mkdir($sourcePath, 0755, true);
+        }
+
         $service = new GlideService;
 
         $validPath = 'images/test.jpg';


### PR DESCRIPTION
## Summary
- Add Laravel 13 (testbench 11) to the GitHub Actions test matrix to match the recently added Laravel 13 support in `composer.json`
- Fix `PathTraversalTest::allows valid paths after decoding` that failed in CI because the configured source directory doesn't exist on disk

## Test plan
- [ ] Verify CI passes for all Laravel versions (11, 12, 13) on PHP 8.3 and 8.4
- [ ] Confirm the previously failing path traversal test now passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)